### PR TITLE
feat: discard all drafts button in sidebar

### DIFF
--- a/cli/src/commands/drafts.ts
+++ b/cli/src/commands/drafts.ts
@@ -1,4 +1,5 @@
-import { deleteDraft, listDrafts, readDraft } from "@pulse/shared";
+import { deleteDraft, listDrafts } from "@pulse/shared";
+import type { LocalDraft } from "@pulse/shared";
 import { loadConfig } from "../config";
 import { apiPost } from "../http";
 import { banner, c, error, info, success, warn } from "../output";
@@ -65,11 +66,7 @@ export async function draftsCommand(_args: string[]): Promise<void> {
 
 async function reviewDraft(
 	config: { apiUrl: string; token?: string; repo: string },
-	draft: typeof listDrafts extends (...a: unknown[]) => infer R
-		? R extends (infer I)[]
-			? I
-			: never
-		: never,
+	draft: LocalDraft,
 ): Promise<void> {
 	console.log("");
 	console.log(`  ${c.bold(`[${draft.data.kind?.toUpperCase()}] ${draft.data.title}`)}`);
@@ -90,7 +87,7 @@ async function reviewDraft(
 
 async function publishOne(
 	config: { apiUrl: string; token?: string; repo: string },
-	draft: { filePath: string; data: Record<string, unknown> },
+	draft: LocalDraft,
 ): Promise<void> {
 	try {
 		const payload = { ...draft.data, status: "published" };
@@ -104,7 +101,7 @@ async function publishOne(
 
 async function publishAll(
 	config: { apiUrl: string; token?: string; repo: string },
-	drafts: Array<{ filePath: string; data: Record<string, unknown> }>,
+	drafts: LocalDraft[],
 ): Promise<void> {
 	let published = 0;
 	for (const draft of drafts) {

--- a/extension/package.json
+++ b/extension/package.json
@@ -103,6 +103,11 @@
 				"icon": "$(trash)"
 			},
 			{
+				"command": "pulse.discardAllDrafts",
+				"title": "Pulse: Discard All Drafts",
+				"icon": "$(clear-all)"
+			},
+			{
 				"command": "pulse.publishDraft",
 				"title": "Pulse: Publish Draft",
 				"icon": "$(cloud-upload)"
@@ -176,6 +181,11 @@
 					"command": "pulse.refresh",
 					"when": "view == pulse.drafts",
 					"group": "navigation"
+				},
+				{
+					"command": "pulse.discardAllDrafts",
+					"when": "view == pulse.drafts",
+					"group": "navigation@99"
 				},
 				{
 					"command": "pulse.search",

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -169,6 +169,40 @@ export function activate(context: vscode.ExtensionContext): void {
 		}),
 	);
 
+	// Discard ALL visible drafts (local only — does not publish)
+	context.subscriptions.push(
+		vscode.commands.registerCommand("pulse.discardAllDrafts", async () => {
+			const visible = draftsTree?.getVisibleDrafts() ?? [];
+			if (visible.length === 0) {
+				vscode.window.showInformationMessage("Pulse: No drafts to discard.");
+				return;
+			}
+			const confirm = await vscode.window.showWarningMessage(
+				`Discard ${visible.length} draft${visible.length === 1 ? "" : "s"}? This deletes the local files and cannot be undone.`,
+				{ modal: true },
+				"Discard All",
+			);
+			if (confirm !== "Discard All") return;
+			let failed = 0;
+			for (const d of visible) {
+				try {
+					deleteDraft(d.filePath);
+				} catch {
+					failed++;
+				}
+			}
+			draftsTree?.refresh();
+			const deleted = visible.length - failed;
+			if (failed === 0) {
+				vscode.window.showInformationMessage(`Pulse: Discarded ${deleted} drafts.`);
+			} else {
+				vscode.window.showWarningMessage(
+					`Pulse: Discarded ${deleted} drafts, ${failed} failed.`,
+				);
+			}
+		}),
+	);
+
 	// Open draft in webview detail panel
 	context.subscriptions.push(
 		vscode.commands.registerCommand("pulse.openDraft", (draft: LocalDraft) => {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -196,9 +196,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			if (failed === 0) {
 				vscode.window.showInformationMessage(`Pulse: Discarded ${deleted} drafts.`);
 			} else {
-				vscode.window.showWarningMessage(
-					`Pulse: Discarded ${deleted} drafts, ${failed} failed.`,
-				);
+				vscode.window.showWarningMessage(`Pulse: Discarded ${deleted} drafts, ${failed} failed.`);
 			}
 		}),
 	);

--- a/extension/src/providers/drafts-tree.ts
+++ b/extension/src/providers/drafts-tree.ts
@@ -77,10 +77,12 @@ export class DraftsTreeProvider implements vscode.TreeDataProvider<DraftTreeNode
 	private timer: ReturnType<typeof setInterval> | null = null;
 
 	get draftCount(): number {
-		if (this.repo) {
-			return this.drafts.filter((d) => d.data.repo === this.repo).length;
-		}
-		return this.drafts.length;
+		return this.getVisibleDrafts().length;
+	}
+
+	getVisibleDrafts(): LocalDraft[] {
+		if (this.repo) return this.drafts.filter((d) => d.data.repo === this.repo);
+		return this.drafts;
 	}
 
 	constructor(private repo: string) {


### PR DESCRIPTION
## Summary
- Adds a `Discard All Drafts` button to the top of the Drafts view in the Pulse sidebar
- Deletes the local draft JSON files only — does **not** publish, so accumulated noise doesn't pollute the team database
- Respects the view scope: if a repo is detected, discards only that repo's drafts; in discovery mode, discards all

## Why
Drafts accumulate fast (500+ in my case) and the only way to clean up was deleting one by one from the inline trash icon. Publishing was not an option because it would push junk to the shared knowledge base.

## Test plan
- [x] Built locally with `node esbuild.mjs --watch` and ran via Extension Development Host (F5)
- [x] Button appears at the top-right of the Drafts view next to refresh
- [x] Modal confirmation shows correct count
- [x] Cancel leaves drafts untouched
- [x] Confirm deletes all visible drafts and refreshes the tree
- [x] No API calls made during discard
- [x] `bun run lint` clean
- [x] `bun run format` clean