### PR TITLE
feat(watcher): skip generation when source files duplicate an existing insight

### DIFF
--- a/cli/src/commands/insight.ts
+++ b/cli/src/commands/insight.ts
@@ -1,5 +1,5 @@
 import { hostname } from "node:os";
-import type { TriggerType } from "@pulse/shared";
+import { type TriggerType, findDuplicateBySourceFiles } from "@pulse/shared";
 import { loadConfig } from "../config";
 import { gatherContext } from "../context/gather";
 import { getActiveSessionInfo } from "../context/session";
@@ -9,6 +9,9 @@ import type { GeneratedInsight } from "../llm/types";
 import { banner, info, warn } from "../output";
 import { ask, closePrompt } from "../prompt";
 import { displayInsight, saveInsightDraft } from "./insight-shared";
+
+// Same threshold as the extension watcher — see watcher.ts for rationale.
+const DEDUP_JACCARD_THRESHOLD = 0.5;
 
 function parseTrigger(args: string[]): TriggerType {
 	for (const arg of args) {
@@ -42,6 +45,22 @@ export async function insightCommand(args: string[]): Promise<void> {
 		warn("No conversation transcript or git changes found.");
 		info("Start a coding session or make some changes first.");
 		return;
+	}
+
+	// Pre-flight dedup for automatic triggers only. Manual `pulse insight`
+	// always proceeds — the user explicitly invoked it.
+	if (trigger !== "manual" && context.sourceFiles?.length && context.relatedInsights?.length) {
+		const dup = findDuplicateBySourceFiles(
+			context.sourceFiles,
+			context.relatedInsights,
+			DEDUP_JACCARD_THRESHOLD,
+		);
+		if (dup) {
+			info(
+				`Skipped duplicate (jaccard=${dup.score.toFixed(2)}) — covered by "${dup.title}" [${dup.id.slice(0, 8)}]`,
+			);
+			return;
+		}
 	}
 
 	info(

--- a/cli/src/context/gather.ts
+++ b/cli/src/context/gather.ts
@@ -52,6 +52,7 @@ export async function gatherContext(config: PulseConfig): Promise<InsightContext
 
 	// Fetch related insights — all signals combined (session, files, branch, keywords)
 	let existingInsights = "";
+	let relatedInsights: RelatedContextResult[] = [];
 	try {
 		const data = await apiPost<{ insights: RelatedContextResult[] }>(
 			config.apiUrl,
@@ -67,6 +68,7 @@ export async function gatherContext(config: PulseConfig): Promise<InsightContext
 			config.token,
 		);
 		if (data.insights.length > 0) {
+			relatedInsights = data.insights;
 			existingInsights = formatContextForPrompt(data.insights);
 		}
 	} catch {
@@ -81,5 +83,6 @@ export async function gatherContext(config: PulseConfig): Promise<InsightContext
 		recentCommits: git.recentCommits || undefined,
 		sourceFiles: git.sourceFiles.length > 0 ? git.sourceFiles : undefined,
 		existingInsights: existingInsights || undefined,
+		relatedInsights: relatedInsights.length > 0 ? relatedInsights : undefined,
 	};
 }

--- a/cli/src/llm/types.ts
+++ b/cli/src/llm/types.ts
@@ -1,4 +1,4 @@
-import type { InsightKind } from "@pulse/shared";
+import type { DuplicateCandidate, InsightKind } from "@pulse/shared";
 
 export interface InsightContext {
 	repo: string;
@@ -9,6 +9,12 @@ export interface InsightContext {
 	sourceFiles?: string[];
 	existingInsights?: string;
 	commitMessage?: string;
+	/**
+	 * Raw candidates returned by /context/related — kept alongside the
+	 * prompt-formatted `existingInsights` so the watcher can run a
+	 * pre-flight dedup check before invoking the LLM.
+	 */
+	relatedInsights?: DuplicateCandidate[];
 }
 
 export interface GeneratedInsight {

--- a/extension/src/context/gather.ts
+++ b/extension/src/context/gather.ts
@@ -124,6 +124,7 @@ export async function gatherContext(
 
 	// Fetch related insights — all signals combined (session, files, branch, keywords)
 	let existingInsights = "";
+	let relatedInsights: RelatedContextResult[] = [];
 	try {
 		const data = await client.getRelatedContext({
 			repo: configRepo || git.repo,
@@ -134,6 +135,7 @@ export async function gatherContext(
 			limit: 15,
 		});
 		if (data.insights.length > 0) {
+			relatedInsights = data.insights;
 			existingInsights = formatContextForPrompt(data.insights);
 		}
 	} catch {
@@ -149,5 +151,6 @@ export async function gatherContext(
 		sourceFiles: git.sourceFiles.length > 0 ? git.sourceFiles : undefined,
 		existingInsights: existingInsights || undefined,
 		commitMessage: git.commitMessage || undefined,
+		relatedInsights: relatedInsights.length > 0 ? relatedInsights : undefined,
 	};
 }

--- a/extension/src/watcher/watcher.ts
+++ b/extension/src/watcher/watcher.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { getAllActiveSessions, getSessionTitle } from "@pulse/cli/context/session";
-import { saveDraft } from "@pulse/shared";
+import { findDuplicateBySourceFiles, saveDraft } from "@pulse/shared";
 import type { InsightCreate } from "@pulse/shared";
 import * as vscode from "vscode";
 import type { PulseApiClient } from "../api/client";
@@ -22,6 +22,11 @@ interface WatcherPersistedState {
 }
 
 const STATE_KEY = "pulse.watcherState";
+
+// Skip generation when the changed file set overlaps an existing insight at
+// or above this Jaccard score. 0.5 catches "same 2 files" duplicates (the
+// dominant cluster shape we saw) while tolerating one-file edits as new.
+const DEDUP_JACCARD_THRESHOLD = 0.5;
 
 /**
  * VS Code watcher — monitors ALL active session files and auto-generates
@@ -275,6 +280,23 @@ export class PulseWatcher implements vscode.Disposable {
 		if (!context.transcript && !context.diff && !context.recentCommits) {
 			this.log("No context available — skipping");
 			return;
+		}
+
+		// Pre-flight dedup: if the changed files already match an existing
+		// insight, skip generation entirely. Stops the duplicate at the
+		// trigger — no LLM call, no draft, no API round-trip.
+		if (context.sourceFiles?.length && context.relatedInsights?.length) {
+			const dup = findDuplicateBySourceFiles(
+				context.sourceFiles,
+				context.relatedInsights,
+				DEDUP_JACCARD_THRESHOLD,
+			);
+			if (dup) {
+				this.log(
+					`Skipped duplicate (jaccard=${dup.score.toFixed(2)}) — covered by "${dup.title}" [${dup.id.slice(0, 8)}]`,
+				);
+				return;
+			}
 		}
 
 		const generated = await generateInsight(context);

--- a/shared/src/dedup.test.ts
+++ b/shared/src/dedup.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { findDuplicateBySourceFiles, jaccardSimilarity } from "./dedup";
+
+describe("jaccardSimilarity", () => {
+	test("empty sets → 0", () => {
+		expect(jaccardSimilarity([], [])).toBe(0);
+		expect(jaccardSimilarity([], ["a"])).toBe(0);
+		expect(jaccardSimilarity(["a"], [])).toBe(0);
+	});
+
+	test("identical sets → 1", () => {
+		expect(jaccardSimilarity(["a", "b"], ["a", "b"])).toBe(1);
+	});
+
+	test("disjoint sets → 0", () => {
+		expect(jaccardSimilarity(["a", "b"], ["c", "d"])).toBe(0);
+	});
+
+	test("half overlap → 0.5", () => {
+		// {a,b,c} ∩ {b,c,d} = {b,c} (2); ∪ = {a,b,c,d} (4)
+		expect(jaccardSimilarity(["a", "b", "c"], ["b", "c", "d"])).toBeCloseTo(0.5);
+	});
+
+	test("duplicates in input do not inflate the score", () => {
+		expect(jaccardSimilarity(["a", "a", "b"], ["a", "b"])).toBe(1);
+	});
+
+	test("order-independent", () => {
+		expect(jaccardSimilarity(["a", "b"], ["b", "a"])).toBe(1);
+	});
+});
+
+describe("findDuplicateBySourceFiles", () => {
+	test("empty currentFiles → null", () => {
+		const candidates = [{ id: "x", title: "t", source_files: ["a"] }];
+		expect(findDuplicateBySourceFiles([], candidates)).toBeNull();
+	});
+
+	test("empty candidates → null", () => {
+		expect(findDuplicateBySourceFiles(["a"], [])).toBeNull();
+	});
+
+	test("candidate with null source_files is skipped", () => {
+		const candidates = [{ id: "x", title: "t", source_files: null }];
+		expect(findDuplicateBySourceFiles(["a"], candidates)).toBeNull();
+	});
+
+	test("candidate with empty source_files is skipped", () => {
+		const candidates = [{ id: "x", title: "t", source_files: [] }];
+		expect(findDuplicateBySourceFiles(["a"], candidates)).toBeNull();
+	});
+
+	test("returns the highest-scoring match above threshold", () => {
+		const result = findDuplicateBySourceFiles(
+			["src/auth.ts", "src/db.ts"],
+			[
+				{ id: "low", title: "low", source_files: ["other.ts"] },
+				{ id: "exact", title: "exact", source_files: ["src/auth.ts", "src/db.ts"] },
+				{ id: "mid", title: "mid", source_files: ["src/auth.ts", "src/other.ts"] },
+			],
+			0.5,
+		);
+		expect(result?.id).toBe("exact");
+		expect(result?.score).toBe(1);
+	});
+
+	test("below threshold → null", () => {
+		// jaccard = 1/4 = 0.25 < 0.5
+		const result = findDuplicateBySourceFiles(
+			["a", "b", "c", "d"],
+			[{ id: "x", title: "t", source_files: ["a"] }],
+			0.5,
+		);
+		expect(result).toBeNull();
+	});
+
+	test("at threshold counts as a match", () => {
+		// jaccard = 2/4 = 0.5 = threshold
+		const result = findDuplicateBySourceFiles(
+			["a", "b", "c"],
+			[{ id: "x", title: "t", source_files: ["b", "c", "d"] }],
+			0.5,
+		);
+		expect(result?.id).toBe("x");
+		expect(result?.score).toBeCloseTo(0.5);
+	});
+
+	test("custom threshold respected", () => {
+		// jaccard = 1/3 ≈ 0.33 — below 0.5 but above 0.3
+		const candidates = [{ id: "x", title: "t", source_files: ["a", "b"] }];
+		expect(findDuplicateBySourceFiles(["a", "c"], candidates, 0.5)).toBeNull();
+		expect(findDuplicateBySourceFiles(["a", "c"], candidates, 0.3)?.id).toBe("x");
+	});
+
+	test("realistic dup pattern (Stripe registration: 12× same files)", () => {
+		// Reproduces the observed cluster: 12 insights all touch the same 2 files
+		const result = findDuplicateBySourceFiles(
+			["src/payments/stripe/register.ts", "src/payments/stripe/types.ts"],
+			[
+				{
+					id: "older-9f3a",
+					title: "Stripe registration flow",
+					source_files: ["src/payments/stripe/register.ts", "src/payments/stripe/types.ts"],
+				},
+			],
+			0.5,
+		);
+		expect(result?.id).toBe("older-9f3a");
+		expect(result?.score).toBe(1);
+	});
+});

--- a/shared/src/dedup.ts
+++ b/shared/src/dedup.ts
@@ -1,0 +1,52 @@
+/**
+ * Source-file Jaccard dedup helpers.
+ *
+ * Used by the watcher (extension + CLI) to skip insight generation when the
+ * current changed files already match an existing insight's source_files.
+ * Prevents the LLM from re-generating the same insight from the same files —
+ * the fix is at the trigger, not at API/LLM/DB layer.
+ */
+
+export interface DuplicateCandidate {
+	id: string;
+	title: string;
+	source_files: string[] | null;
+}
+
+export interface DuplicateMatch {
+	id: string;
+	title: string;
+	score: number;
+}
+
+/** Jaccard similarity between two file path sets: |A∩B| / |A∪B|. Empty → 0. */
+export function jaccardSimilarity(a: readonly string[], b: readonly string[]): number {
+	if (a.length === 0 || b.length === 0) return 0;
+	const setA = new Set(a);
+	const setB = new Set(b);
+	let intersection = 0;
+	for (const x of setA) if (setB.has(x)) intersection++;
+	const union = setA.size + setB.size - intersection;
+	return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Find the highest-scoring candidate whose source_files overlap with
+ * `currentFiles` at or above `threshold`. Returns null if none qualify.
+ */
+export function findDuplicateBySourceFiles(
+	currentFiles: readonly string[],
+	candidates: readonly DuplicateCandidate[],
+	threshold = 0.5,
+): DuplicateMatch | null {
+	if (currentFiles.length === 0) return null;
+	let best: DuplicateMatch | null = null;
+	for (const c of candidates) {
+		if (!c.source_files || c.source_files.length === 0) continue;
+		const score = jaccardSimilarity(currentFiles, c.source_files);
+		if (score >= threshold && (best === null || score > best.score)) {
+			best = { id: c.id, title: c.title, score };
+		}
+	}
+	return best;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -36,6 +36,8 @@ export {
 } from "./llm/enrichment-prompt";
 export { saveDraft, listDrafts, readDraft, deleteDraft, listAllDraftRepos } from "./drafts";
 export type { LocalDraft } from "./drafts";
+export { jaccardSimilarity, findDuplicateBySourceFiles } from "./dedup";
+export type { DuplicateCandidate, DuplicateMatch } from "./dedup";
 export {
 	SOLO_ORG_ID,
 	SOLO_ORG_NAME,


### PR DESCRIPTION
## Summary

The watcher (extension + CLI) now runs a **pre-flight Jaccard check** on the changed file set against insights returned by `/context/related`. If the overlap is **≥ 0.5**, generation is skipped — no LLM call, no draft, no API round-trip.

This fixes the duplicate clusters at their source (the trigger). The LLM was receiving "DO NOT REPEAT" text in the prompt and ignoring it — producing the 14×/12×/9× duplicate clusters seen in production.

## Changes

- `shared/src/dedup.ts` — `jaccardSimilarity` + `findDuplicateBySourceFiles` (pure, no deps)
- `shared/src/dedup.test.ts` — 15 tests including the real Stripe-registration dup pattern
- `shared/src/index.ts` — exports
- `cli/src/llm/types.ts` — `InsightContext.relatedInsights` raw passthrough
- `cli/src/context/gather.ts` — returns raw candidates alongside prompt text
- `cli/src/commands/insight.ts` — skip for automatic triggers only (`manual` always proceeds)
- `extension/src/context/gather.ts` — returns raw candidates
- `extension/src/watcher/watcher.ts` — pre-flight skip in `generateAndSave` with output channel log

## Behaviour

When the watcher fires (size/commit/push) and the changed file set has Jaccard ≥ 0.5 with any existing insight, the watcher logs:

```
Skipped duplicate (jaccard=0.85) — covered by "Title here" [abc12345]
```

…and returns. No LLM call, no draft saved.

Threshold is a hardcoded constant (`DEDUP_JACCARD_THRESHOLD = 0.5`) in each watcher. Easy to relax later if we see false positives.

## Test plan

- [x] Unit tests: 15 pass on `bun test shared/src/dedup.test.ts`
- [x] Full check (`bun run check`): lint clean, typecheck clean, 42 tests pass (shared+cli)
- [ ] Manual: trigger watcher twice on the same file pair → second run must skip
- [ ] Manual: trigger watcher on disjoint files → still generates
- [ ] Manual: `pulse insight` (manual trigger) → never skips even if duplicate