### PR TITLE
feat(gap): add foundation for gap-extraction insights (Phase 1 — types + prompt + parsers, no wiring)

### DIFF
--- a/api/migrations/016_kind_gap.sql
+++ b/api/migrations/016_kind_gap.sql
@@ -1,0 +1,8 @@
+-- Add 'gap' to the insights kind check constraint.
+-- The 'gap' kind is for insights that capture a moment of asymmetric-information
+-- transfer between a human and an AI during a vibecoding session — the substance
+-- of what the human had to intervene with, abstracted away from tone.
+-- See shared/src/llm/prompt.ts → GAP_INSIGHT_SYSTEM_PROMPT.
+ALTER TABLE insights DROP CONSTRAINT IF EXISTS insights_kind_check;
+ALTER TABLE insights ADD CONSTRAINT insights_kind_check
+  CHECK (kind = ANY (ARRAY['decision', 'dead_end', 'pattern', 'context', 'progress', 'business', 'gap']));

--- a/api/src/schemas/insight.ts
+++ b/api/src/schemas/insight.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
-const insightKind = z.enum(["decision", "dead_end", "pattern", "context", "progress", "business"]);
+const insightKind = z.enum([
+	"decision",
+	"dead_end",
+	"pattern",
+	"context",
+	"progress",
+	"business",
+	"gap",
+]);
 const insightStatus = z.enum(["draft", "published"]);
 const triggerType = z.enum(["commit", "size", "manual", "push", "api"]);
 

--- a/extension/src/utils/format.ts
+++ b/extension/src/utils/format.ts
@@ -37,6 +37,7 @@ export function kindLabel(kind: InsightKind): string {
 		context: "Context",
 		progress: "Progress",
 		business: "Business",
+		gap: "Gap",
 	};
 	return labels[kind] ?? kind;
 }
@@ -50,6 +51,7 @@ export function kindIcon(kind: InsightKind): vscode.ThemeIcon {
 		context: "info",
 		progress: "check",
 		business: "briefcase",
+		gap: "comment-discussion",
 	};
 	return new vscode.ThemeIcon(icons[kind] ?? "circle-outline");
 }

--- a/extension/src/views/detail-html.ts
+++ b/extension/src/views/detail-html.ts
@@ -7,6 +7,7 @@ const KIND_COLORS: Record<InsightKind, string> = {
 	context: "#60a5fa",
 	progress: "#34d399",
 	business: "#fbbf24",
+	gap: "#7cc4ff",
 };
 
 function escapeHtml(str: string): string {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,6 @@
 export type {
+	GapInsightStructured,
+	GapType,
 	Insight,
 	InsightCreate,
 	InsightEnrichment,
@@ -24,7 +26,19 @@ export type {
 	User,
 	UserRole,
 } from "./types/org";
-export { INSIGHT_SYSTEM_PROMPT } from "./llm/prompt";
+export { GAP_INSIGHT_SYSTEM_PROMPT, INSIGHT_SYSTEM_PROMPT } from "./llm/prompt";
+export {
+	buildGapUserPrompt,
+	extractHumanInterventions,
+	isNoiseMessage,
+	parseGapResponse,
+	parseTranscriptTurns,
+} from "./llm/gap";
+export type {
+	GapResponse,
+	InterventionWindow,
+	TranscriptTurn,
+} from "./llm/gap";
 export {
 	ASK_SYSTEM_PROMPT,
 	buildAskUserPrompt,

--- a/shared/src/llm/gap.test.ts
+++ b/shared/src/llm/gap.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildGapUserPrompt,
+	extractHumanInterventions,
+	isNoiseMessage,
+	parseGapResponse,
+	parseTranscriptTurns,
+} from "./gap";
+
+describe("parseTranscriptTurns", () => {
+	test("parses alternating USER/ASSISTANT blocks", () => {
+		const t = "[USER] hello\n\n[ASSISTANT] hi there\n\n[USER] do X\n";
+		const r = parseTranscriptTurns(t);
+		expect(r).toEqual([
+			{ role: "user", text: "hello" },
+			{ role: "assistant", text: "hi there" },
+			{ role: "user", text: "do X" },
+		]);
+	});
+
+	test("handles multi-line bodies", () => {
+		const t = "[USER] first line\nsecond line\n\n[ASSISTANT] reply";
+		const r = parseTranscriptTurns(t);
+		expect(r).toHaveLength(2);
+		expect(r[0].text).toBe("first line\nsecond line");
+	});
+
+	test("empty/whitespace returns empty list", () => {
+		expect(parseTranscriptTurns("")).toEqual([]);
+		expect(parseTranscriptTurns("   \n  \n")).toEqual([]);
+	});
+
+	test("is case-insensitive on role tags", () => {
+		const r = parseTranscriptTurns("[user] hello\n[Assistant] hi");
+		expect(r).toEqual([
+			{ role: "user", text: "hello" },
+			{ role: "assistant", text: "hi" },
+		]);
+	});
+
+	test("ignores leading text before first role tag", () => {
+		const r = parseTranscriptTurns("preamble noise\n[USER] real message");
+		expect(r).toEqual([{ role: "user", text: "real message" }]);
+	});
+});
+
+describe("isNoiseMessage", () => {
+	test("rejects pure confirmations", () => {
+		expect(isNoiseMessage("ok")).toBe(true);
+		expect(isNoiseMessage("yes")).toBe(true);
+		expect(isNoiseMessage("sim claro")).toBe(true);
+		expect(isNoiseMessage("perfeito")).toBe(true);
+		expect(isNoiseMessage("ultrathink go")).toBe(true);
+		expect(isNoiseMessage("ultrathink, continua")).toBe(true);
+		expect(isNoiseMessage("continue")).toBe(true);
+		expect(isNoiseMessage("obrigado")).toBe(true);
+	});
+
+	test("rejects messages under 15 chars", () => {
+		expect(isNoiseMessage("hi")).toBe(true);
+		expect(isNoiseMessage("abc")).toBe(true);
+	});
+
+	test("accepts substantive interventions", () => {
+		expect(isNoiseMessage("but the client actually does X")).toBe(false);
+		expect(isNoiseMessage("mas calma — isto é tratar a consequência")).toBe(false);
+		expect(isNoiseMessage("no, use NextAuth, not Clerk")).toBe(false);
+	});
+});
+
+describe("extractHumanInterventions", () => {
+	test("skips the first human turn (problem definition)", () => {
+		const turns = parseTranscriptTurns(
+			"[USER] please build feature X\n\n[ASSISTANT] starting\n\n[USER] also the api must validate input thoroughly\n",
+		);
+		const w = extractHumanInterventions(turns);
+		expect(w).toHaveLength(1);
+		expect(w[0].human_text).toContain("api must validate");
+	});
+
+	test("skips noise messages", () => {
+		const turns = parseTranscriptTurns(
+			"[USER] build feature\n\n[ASSISTANT] starting\n\n[USER] ok\n\n[ASSISTANT] continuing\n\n[USER] actually wait, also support feature Y not just X\n",
+		);
+		const w = extractHumanInterventions(turns);
+		expect(w).toHaveLength(1);
+		expect(w[0].human_text).toContain("feature Y");
+	});
+
+	test("builds windows with proper before/after slicing", () => {
+		const turns = parseTranscriptTurns(
+			[
+				"[USER] kick-off",
+				"",
+				"[ASSISTANT] A1",
+				"",
+				"[ASSISTANT] A2",
+				"",
+				"[ASSISTANT] A3",
+				"",
+				"[USER] correction with enough text to matter",
+				"",
+				"[ASSISTANT] noted",
+			].join("\n"),
+		);
+		const w = extractHumanInterventions(turns, { before: 2, after: 1 });
+		expect(w).toHaveLength(1);
+		expect(w[0].before.map((t) => t.text)).toEqual(["A2", "A3"]);
+		expect(w[0].after).toHaveLength(1);
+		expect(w[0].after[0].text).toBe("noted");
+	});
+});
+
+describe("buildGapUserPrompt", () => {
+	test("includes context, the human's message, and after-turn", () => {
+		const prompt = buildGapUserPrompt({
+			idx: 2,
+			human_text: "no, use approach Y instead",
+			before: [
+				{ role: "user", text: "build X" },
+				{ role: "assistant", text: "implementing X with approach Z" },
+			],
+			after: [{ role: "assistant", text: "switching to Y" }],
+		});
+		expect(prompt).toContain("THE HUMAN'S MESSAGE");
+		expect(prompt).toContain("no, use approach Y instead");
+		expect(prompt).toContain("implementing X with approach Z");
+		expect(prompt).toContain("switching to Y");
+		expect(prompt).toContain("rejected");
+	});
+
+	test("truncates very long turns in context", () => {
+		const longText = "A".repeat(3000);
+		const prompt = buildGapUserPrompt({
+			idx: 2,
+			human_text: "ok",
+			before: [{ role: "assistant", text: longText }],
+			after: [],
+		});
+		expect(prompt).toContain("…");
+		expect(prompt.length).toBeLessThan(3500);
+	});
+});
+
+describe("parseGapResponse", () => {
+	test("parses a well-formed JSON response", () => {
+		const raw = JSON.stringify({
+			title: "Email sender domain is glie.ai, not pulse.glie.ai",
+			gap_type: "domain",
+			ai_assumption: "Used pulse.glie.ai as the email sender domain.",
+			human_contribution: "Indicated the sender domain should be glie.ai (root domain).",
+			why_invisible_to_ai: "AI cannot inspect the deployed env file.",
+			for_next_session: "Use @glie.ai for outbound email, not @pulse.glie.ai.",
+			rejected: false,
+		});
+		const r = parseGapResponse(raw);
+		expect(r).not.toBeNull();
+		if (!r || r.rejected) throw new Error("expected non-rejected");
+		expect(r.title).toContain("glie.ai");
+		expect(r.gap_type).toBe("domain");
+	});
+
+	test("parses a code-fenced JSON response", () => {
+		const obj = {
+			title: "T",
+			gap_type: "preference",
+			ai_assumption: "A",
+			human_contribution: "C",
+			why_invisible_to_ai: "W",
+			for_next_session: "F",
+			rejected: false,
+		};
+		const raw = `\`\`\`json\n${JSON.stringify(obj)}\n\`\`\``;
+		const r = parseGapResponse(raw);
+		expect(r).not.toBeNull();
+		if (!r || r.rejected) throw new Error("expected non-rejected");
+		expect(r.title).toBe("T");
+	});
+
+	test("returns null on malformed JSON", () => {
+		expect(parseGapResponse("not json")).toBeNull();
+		expect(parseGapResponse("")).toBeNull();
+	});
+
+	test("returns null when required fields are missing", () => {
+		const raw = JSON.stringify({ title: "T", gap_type: "domain", rejected: false });
+		expect(parseGapResponse(raw)).toBeNull();
+	});
+
+	test("recognises a rejected response", () => {
+		const r = parseGapResponse(JSON.stringify({ rejected: true, reason: "pure confirmation" }));
+		expect(r).toEqual({ rejected: true, reason: "pure confirmation" });
+	});
+
+	test("clamps an invalid gap_type to methodology rather than dropping", () => {
+		const raw = JSON.stringify({
+			title: "T",
+			gap_type: "made-up-type",
+			ai_assumption: "A",
+			human_contribution: "C",
+			why_invisible_to_ai: "W",
+			for_next_session: "F",
+			rejected: false,
+		});
+		const r = parseGapResponse(raw);
+		expect(r).not.toBeNull();
+		if (!r || r.rejected) throw new Error("expected non-rejected");
+		expect(r.gap_type).toBe("methodology");
+	});
+});

--- a/shared/src/llm/gap.ts
+++ b/shared/src/llm/gap.ts
@@ -1,0 +1,234 @@
+/**
+ * Gap-extraction helpers.
+ *
+ * The flow:
+ *   1. parseTranscriptTurns(transcript)   → ordered list of (role, text)
+ *   2. extractHumanInterventions(turns)   → array of windows around each human turn
+ *   3. buildGapUserPrompt(window)         → string to send as user message
+ *   4. (LLM call with GAP_INSIGHT_SYSTEM_PROMPT)
+ *   5. parseGapResponse(raw)              → GapResponse | null
+ *
+ * The transcript format expected here matches what `formatTranscript`
+ * produces in @pulse/cli/context/session: alternating `[USER] ...` and
+ * `[ASSISTANT] ...` blocks separated by blank lines.
+ */
+
+import type { GapInsightStructured, GapType } from "../types/insight";
+
+// ─── Types ────────────────────────────────────────
+
+export interface TranscriptTurn {
+	role: "user" | "assistant";
+	text: string;
+}
+
+export interface InterventionWindow {
+	idx: number; // 1-based index among human turns
+	human_text: string;
+	before: TranscriptTurn[];
+	after: TranscriptTurn[];
+}
+
+export type GapResponse =
+	| ({ rejected: false } & GapInsightStructured & {
+				title: string;
+				for_next_session: string;
+			})
+	| { rejected: true; reason: string };
+
+// ─── Parsing ──────────────────────────────────────
+
+const TURN_PREFIX_RE = /^\[(USER|ASSISTANT)\]\s*/i;
+
+/** Parse a formatted transcript ([USER] ... / [ASSISTANT] ...) into turns. */
+export function parseTranscriptTurns(transcript: string): TranscriptTurn[] {
+	if (!transcript || !transcript.trim()) return [];
+	const turns: TranscriptTurn[] = [];
+	let currentRole: TranscriptTurn["role"] | null = null;
+	let buf: string[] = [];
+
+	const flush = () => {
+		if (currentRole && buf.length > 0) {
+			const text = buf.join("\n").trim();
+			if (text) turns.push({ role: currentRole, text });
+		}
+		buf = [];
+	};
+
+	for (const raw of transcript.split("\n")) {
+		const line = raw.trimEnd();
+		const match = line.match(TURN_PREFIX_RE);
+		if (match) {
+			flush();
+			currentRole = match[1].toLowerCase() === "user" ? "user" : "assistant";
+			buf.push(line.slice(match[0].length));
+		} else if (currentRole) {
+			buf.push(line);
+		}
+	}
+	flush();
+	return turns;
+}
+
+// ─── Window extraction ────────────────────────────
+
+/**
+ * Heuristic: messages that are not real interventions. We try to reject
+ * these BEFORE the LLM call to save tokens; the LLM rejects further with
+ * its own filter for anything that slips through.
+ */
+const NOISE_PATTERNS: RegExp[] = [
+	/^(ok|okay|yes|yep|sim|claro|perfect|perfeito|certo|done|ready|nice|great|good|optimo|óptimo|fixe)[\s.!?]*$/i,
+	/^(continue|continua|go|vai|avante|next|próximo|proximo|avança|avanca)[\s.!?]*$/i,
+	/^ultrathink[\s.,]*(go|vai|continue|continua)?[\s.!?]*$/i,
+	/^(thanks|obrigado|obrigada|ty)[\s.!?]*$/i,
+];
+
+const MIN_TURN_CHARS = 15;
+// Number of turns to include in the window before/after the intervention,
+// counted regardless of role. 2 before + 1 after gives the LLM enough to
+// reconstruct what the AI was doing without inflating the prompt budget.
+const DEFAULT_WINDOW_BEFORE = 2;
+const DEFAULT_WINDOW_AFTER = 1;
+
+/** True if a human message is clearly noise (pure confirmation, unblock, etc). */
+export function isNoiseMessage(text: string): boolean {
+	const trimmed = text.trim();
+	if (trimmed.length < MIN_TURN_CHARS) return true;
+	return NOISE_PATTERNS.some((re) => re.test(trimmed));
+}
+
+/**
+ * Build a window for every non-noise human message after the first one.
+ * The first human turn is the problem framing — not an intervention.
+ */
+export function extractHumanInterventions(
+	turns: readonly TranscriptTurn[],
+	opts: { before?: number; after?: number } = {},
+): InterventionWindow[] {
+	const before = opts.before ?? DEFAULT_WINDOW_BEFORE;
+	const after = opts.after ?? DEFAULT_WINDOW_AFTER;
+
+	const windows: InterventionWindow[] = [];
+	let humanCount = 0;
+	for (let i = 0; i < turns.length; i++) {
+		const t = turns[i];
+		if (t.role !== "user") continue;
+		humanCount++;
+		// Skip the first human turn — it's the problem definition, not a gap.
+		if (humanCount === 1) continue;
+		if (isNoiseMessage(t.text)) continue;
+
+		windows.push({
+			idx: humanCount,
+			human_text: t.text,
+			before: turns.slice(Math.max(0, i - before), i),
+			after: turns.slice(i + 1, i + 1 + after),
+		});
+	}
+	return windows;
+}
+
+// ─── Prompt building ──────────────────────────────
+
+const MAX_TURN_CHARS_IN_PROMPT = 1500;
+
+function truncate(text: string, max = MAX_TURN_CHARS_IN_PROMPT): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** Build the user message for one gap-extraction LLM call. */
+export function buildGapUserPrompt(w: InterventionWindow): string {
+	const lines: string[] = ["# Context window for one human intervention", ""];
+
+	lines.push("## Turns before the human's message");
+	for (const t of w.before) {
+		lines.push(`### [${t.role}]`);
+		lines.push(truncate(t.text));
+		lines.push("");
+	}
+	lines.push("## THE HUMAN'S MESSAGE");
+	lines.push(w.human_text);
+	lines.push("");
+	lines.push("## Assistant's response after");
+	for (const t of w.after) {
+		lines.push(`### [${t.role}]`);
+		lines.push(truncate(t.text));
+		lines.push("");
+	}
+	lines.push("---");
+	lines.push('Extract the gap, or return `{"rejected": true, "reason": "..."}` if there is none.');
+	return lines.join("\n");
+}
+
+// ─── Response parsing ─────────────────────────────
+
+const CODE_FENCE_RE = /^```(?:json)?\s*\n?([\s\S]*?)\n?```$/;
+
+const VALID_GAP_TYPES: ReadonlySet<GapType> = new Set([
+	"domain",
+	"business",
+	"strategic",
+	"past-learning",
+	"preference",
+	"ambiguity",
+	"methodology",
+]);
+
+/**
+ * Strip code fences and parse the LLM response. Returns null on any error;
+ * the caller decides whether to retry or drop. Validates required fields
+ * for non-rejected responses and clamps an invalid `gap_type` to "methodology"
+ * with a console warning rather than dropping the whole response.
+ */
+export function parseGapResponse(raw: string): GapResponse | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+	const cleaned = trimmed.match(CODE_FENCE_RE)?.[1]?.trim() ?? trimmed;
+
+	let obj: unknown;
+	try {
+		obj = JSON.parse(cleaned);
+	} catch {
+		return null;
+	}
+	if (!obj || typeof obj !== "object") return null;
+	const r = obj as Record<string, unknown>;
+
+	if (r.rejected === true) {
+		return { rejected: true, reason: String(r.reason ?? "no reason given") };
+	}
+
+	const title = typeof r.title === "string" ? r.title.trim() : "";
+	const ai_assumption = typeof r.ai_assumption === "string" ? r.ai_assumption.trim() : "";
+	const human_contribution =
+		typeof r.human_contribution === "string" ? r.human_contribution.trim() : "";
+	const why_invisible_to_ai =
+		typeof r.why_invisible_to_ai === "string" ? r.why_invisible_to_ai.trim() : "";
+	const for_next_session = typeof r.for_next_session === "string" ? r.for_next_session.trim() : "";
+
+	if (
+		!title ||
+		!ai_assumption ||
+		!human_contribution ||
+		!why_invisible_to_ai ||
+		!for_next_session
+	) {
+		return null;
+	}
+
+	const rawType = typeof r.gap_type === "string" ? r.gap_type : "";
+	const gap_type: GapType = VALID_GAP_TYPES.has(rawType as GapType)
+		? (rawType as GapType)
+		: "methodology";
+
+	return {
+		rejected: false,
+		title,
+		gap_type,
+		ai_assumption,
+		human_contribution,
+		why_invisible_to_ai,
+		for_next_session,
+	};
+}

--- a/shared/src/llm/prompt.ts
+++ b/shared/src/llm/prompt.ts
@@ -82,3 +82,89 @@ Respond with a single JSON object (no markdown, no code blocks):
   "structured": { ... },
   "sourceFiles": ["file1.ts", "file2.ts"]
 }`;
+
+/**
+ * Gap-extraction system prompt — the "DNA" of a gap insight.
+ *
+ * Used to extract one insight from a single human-intervention moment in a
+ * vibecoding session. Unlike INSIGHT_SYSTEM_PROMPT (which summarises the
+ * whole session into one insight), this prompt is invoked once per moment
+ * where the human typed something non-trivial.
+ *
+ * The prompt enforces a strict privacy rule: the human's tone, profanity,
+ * frustration, or idiosyncratic typing must NEVER appear in the output.
+ * The insight captures substance; the transcript stays on the user's machine.
+ */
+export const GAP_INSIGHT_SYSTEM_PROMPT = `You are analysing one moment in a vibecoding session. The user (human) typed a message that interrupted, corrected, questioned, redirected, or contributed new information to the AI. **Your only job is to articulate the gap that this human intervention closed.**
+
+## The premise
+
+In vibecoding, the human steers the AI through fast iteration. Every time the human intervenes with anything beyond a simple "yes" or "continue", they are contributing **asymmetric information** that the AI did not have. That information is exactly what would be lost when the session ends — and exactly what would be valuable to the next session, the next teammate, or a future retrospective.
+
+There are two types of gap:
+
+- **AI gap** — the AI lacked something it couldn't have inferred: domain knowledge, business constraints, past attempts, strategic priorities, personal preferences, ecosystem facts.
+- **Human gap** — the human didn't communicate something essential in their first prompt: they assumed obvious, forgot, or saw the problem only when output appeared.
+
+Both are valuable to capture. **The information that closed the gap is the artefact**, not the words themselves.
+
+## What you receive
+
+You receive ONE moment from a session: a few turns of context from before the human's message, the human's message verbatim, and one assistant turn after (the resolution). All in the original language (PT or EN, often mixed).
+
+## What you produce
+
+If the human's message reveals a real gap — produce ONE JSON object. If the message is just a confirmation ("ok", "yes do it", "perfect"), a routing instruction ("send me an email"), or a continuation signal ("go on", "ultrathink go") with no new information — produce \`{ "rejected": true, "reason": "..." }\`.
+
+\`\`\`
+{
+  "title": "Short phrase naming the substance of the gap. Tone-neutral. Not a quote.",
+  "gap_type": "domain | business | strategic | past-learning | preference | ambiguity | methodology",
+  "ai_assumption": "What the AI was doing or about to do BEFORE the intervention. Reconstruct from the prior turns.",
+  "human_contribution": "Paraphrased substance of what the human contributed. NEVER verbatim. The reader should understand WHAT was requested, corrected, or revealed — not HOW it was said.",
+  "why_invisible_to_ai": "Why the AI could not have inferred this on its own. Be specific.",
+  "for_next_session": "One actionable sentence the next AI agent (or new human) should know to avoid re-opening this gap.",
+  "rejected": false
+}
+\`\`\`
+
+## Privacy rule — CRITICAL
+
+The insight will be read by other team members, future humans, and other AI agents — possibly in retros, onboarding, or shared dashboards. **The human's tone, emotional charge, frustration, profanity, or idiosyncratic typing style MUST NOT appear in any field of the output.** Extract the substance; discard the form.
+
+Examples of what to drop:
+- "FAZ ESSA MERDA!!!" → render as "Requested completion of the task."
+- "tu não percebes nada do que estás a falar" → "Indicated that the AI's framing was wrong."
+- "obviamente que não" → "Disagreed with the proposed approach."
+- ALL CAPS / multiple exclamation marks → omit the emphasis, keep the request.
+- Personal nicknames, swearing, sarcasm → all drop.
+
+The original transcript stays on the user's machine and never leaves. The insight is the abstraction. If you cannot describe a contribution without invoking tone, write \`"human_contribution": "Indicated that <substance>."\` — bland is better than exposing.
+
+## What makes a gap real (versus noise)
+
+**REAL gap signals:**
+- "no, actually..." / "but..." / "espera..." / "mas..." — the human is correcting an assumption
+- Human introduces a name, constraint, or piece of context not in prior turns
+- Human reframes the problem (not just the solution)
+- Human invokes a value or principle ("don't do X" with no reason the AI could have predicted)
+- Human reveals past attempts or institutional history
+- Human reveals a strategic priority that overrides the AI's optimisation target
+- Human corrects a domain misunderstanding (industry, regulation, niche, customer behaviour)
+
+**NOT a gap (return rejected:true):**
+- Pure approval ("perfect", "yes", "ok")
+- Pure scheduling/routing ("send to email X", "do it Monday at 9")
+- Pure unblocking ("continue", "ultrathink go")
+- Restating something the AI just said
+- Pure typo/clarity request ("explain that again") without new info
+- The human's first prompt of the session (it's the problem definition, not a gap)
+
+## Important rules
+
+1. **Do not invent.** If the prior turns don't show the AI's assumption clearly, write \`"ai_assumption": "Unclear from context — but the human's contribution stands alone as ..."\`. Honesty over fabrication.
+2. **The title is the substance, not the quote.** "PNL: customer churn is monthly, not yearly" — yes. "User said 'no, monthly'" — no.
+3. **The for_next_session is the test.** If a future AI couldn't act on that sentence to avoid the same gap, the insight isn't done.
+4. **Keep the original meaning regardless of language.** If the human spoke PT, render the substance in EN or PT consistently in the output — just no verbatim.
+5. **One gap per moment.** If the human packed three corrections into one message, pick the deepest one.
+6. **Reject generously.** A reject is better than a noise insight. Aim for 30-50% reject rate on a real session.`;

--- a/shared/src/types/insight.ts
+++ b/shared/src/types/insight.ts
@@ -1,4 +1,38 @@
-export type InsightKind = "decision" | "dead_end" | "pattern" | "context" | "progress" | "business";
+export type InsightKind =
+	| "decision"
+	| "dead_end"
+	| "pattern"
+	| "context"
+	| "progress"
+	| "business"
+	| "gap";
+
+/**
+ * Categories of asymmetric information that surface when a human intervenes
+ * during a vibecoding session. Stored under `structured.gap_type` on
+ * insights whose `kind === "gap"`.
+ */
+export type GapType =
+	| "domain"
+	| "business"
+	| "strategic"
+	| "past-learning"
+	| "preference"
+	| "ambiguity"
+	| "methodology";
+
+/**
+ * Structured payload for gap insights. The body of a gap insight is the
+ * `for_next_session` field — the rest live here so they can be queried,
+ * filtered, and rendered separately. NEVER include the human's verbatim
+ * words; only the substance of the intervention. See GAP_INSIGHT_SYSTEM_PROMPT.
+ */
+export interface GapInsightStructured {
+	gap_type: GapType;
+	ai_assumption: string;
+	human_contribution: string;
+	why_invisible_to_ai: string;
+}
 
 export type InsightStatus = "draft" | "published";
 

--- a/web/src/lib/components/FilterBar.svelte
+++ b/web/src/lib/components/FilterBar.svelte
@@ -11,7 +11,15 @@
 		repos?: string[];
 	} = $props();
 
-	const allKinds: InsightKind[] = ["decision", "dead_end", "pattern", "context", "progress", "business"];
+	const allKinds: InsightKind[] = [
+		"decision",
+		"dead_end",
+		"pattern",
+		"context",
+		"progress",
+		"business",
+		"gap",
+	];
 
 	const activeKind = $derived(page.url.searchParams.get("kind") as InsightKind | null);
 	const activeRepo = $derived(page.url.searchParams.get("repo"));
@@ -62,6 +70,10 @@
 		business: {
 			active: "bg-purple-500 text-white",
 			inactive: "bg-purple-500/8 text-purple-400 hover:bg-purple-500/15",
+		},
+		gap: {
+			active: "bg-accent text-white",
+			inactive: "bg-accent/8 text-accent hover:bg-accent/15",
 		},
 	};
 </script>

--- a/web/src/lib/components/KindBadge.svelte
+++ b/web/src/lib/components/KindBadge.svelte
@@ -10,6 +10,7 @@
 		progress: "bg-warning/10 text-warning",
 		context: "bg-text-secondary/10 text-text-secondary",
 		business: "bg-purple-500/10 text-purple-400",
+		gap: "bg-accent/15 text-accent",
 	};
 </script>
 

--- a/web/src/lib/components/StructuredData.svelte
+++ b/web/src/lib/components/StructuredData.svelte
@@ -10,6 +10,7 @@
 		progress: "Milestone",
 		context: "Context",
 		business: "Business constraint",
+		gap: "Information gap closed by human",
 	};
 
 	/** Known fields per kind — everything else goes to fallback */
@@ -20,6 +21,7 @@
 		progress: ["milestone", "deliverables"],
 		context: ["summary"],
 		business: ["problem", "constraints", "drove_decisions"],
+		gap: ["gap_type", "ai_assumption", "human_contribution", "why_invisible_to_ai"],
 	};
 
 	const extraFields = $derived(


### PR DESCRIPTION
## Why this PR exists

After a long review of the 1,329 published insights in production, we converged on a strong thesis: **the highest-value content in a vibecoding session is the asymmetric information the human contributes when they intervene, correct, or redirect the AI** — not the AI's self-narrative of what it implemented.

Today's pipeline produces machine-flavored prose written by the AI about the AI's own work. Algorithmic measurement: ~90% of insights have no human voice signal; the few that do (mostly \`business\` kind) capture exactly the kind of substance that's worth preserving.

This PR lays the foundation for a new \`gap\` insight kind that captures one moment of human intervention per generation — with a strict privacy rule: never echo the human's tone, profanity, or idiosyncrasies, only the substance.

## What's in this PR (Phase 1)

**No behavior change in production.** Nothing in the CLI or extension calls the new code yet. This is foundation only.

- \`api/migrations/016_kind_gap.sql\` — adds \`gap\` to the kind CHECK constraint
- \`shared/src/types/insight.ts\` — \`GapType\` enum, \`GapInsightStructured\` shape
- \`shared/src/llm/prompt.ts\` — \`GAP_INSIGHT_SYSTEM_PROMPT\` with the privacy rule
- \`shared/src/llm/gap.ts\` — \`parseTranscriptTurns\`, \`extractHumanInterventions\`, \`isNoiseMessage\`, \`buildGapUserPrompt\`, \`parseGapResponse\`
- \`shared/src/llm/gap.test.ts\` — 19 unit tests
- zod enum + UI lookups (\`FilterBar\`, \`StructuredData\`, \`KindBadge\`, \`format.ts\`, \`detail-html.ts\`) updated to include \"gap\"

## Validation

Ran a side-by-side experiment over our own meta-session (Pulse, 35 human turns) and a Manager building session (64 human turns) — see \`analysis/2026-05-18-experiment.html\` in the parent repo.

- Current prompt on full meta-session → 1 summary insight (does inferr the thesis but loses all granularity)
- Gap prompt per human window → 26 distinct gap insights + 9 reasoned rejections
- Gap prompt on Manager building session → 15+ gaps + 16 rejections (~48% reject rate, expected on a less-meta session)

Sample gaps captured:
- \"Email sender domain is glie.ai, not pulse.glie.ai\" (\`domain\`)
- \"Pulse duplicates: prevent at watcher, not deduplicate at API/UI\" (\`methodology\`)
- \"Vanilla stack first — don't add libs without clear need\" (\`strategic\`)
- \"Sample size matters: 4/1329 is not a deep dive\" (\`methodology\`)

## Phase 2 (next PR)

- Wire \`generateGapInsights(provider, transcript)\` into the watcher behind a flag (\`PULSE_INSIGHT_MODE=gap\`)
- Add a post-process guard that scans output for verbatim leaks of the human's words and falls back to paraphrase
- New MCP tool descriptions reflecting the gap-first model

## Test plan

- [x] \`bun test shared/src/llm/gap.test.ts\` — 19/19 pass
- [x] \`bun run lint\` — clean
- [x] \`bun run typecheck\` — clean (api/src tests fail with missing env vars; pre-existing)
- [ ] Migration tested against a copy of prod DB
- [ ] No regression in current insight creation (because nothing calls the new path)