### PR TITLE
feat(gap): wire gap-extraction into watcher + CLI behind a feature flag (Phase 2)

### DIFF
--- a/cli/src/commands/insight.ts
+++ b/cli/src/commands/insight.ts
@@ -1,17 +1,32 @@
 import { hostname } from "node:os";
-import { type TriggerType, findDuplicateBySourceFiles } from "@pulse/shared";
+import {
+	GAP_INSIGHT_SYSTEM_PROMPT,
+	type InsightCreate,
+	type TriggerType,
+	findDuplicateBySourceFiles,
+	gapResponseToInsightCreate,
+	generateGapInsights,
+} from "@pulse/shared";
 import { loadConfig } from "../config";
 import { gatherContext } from "../context/gather";
 import { getActiveSessionInfo } from "../context/session";
+import { apiPost } from "../http";
 import { getProviderWithSetup } from "../llm/provider";
 import { resolveLlmConfig } from "../llm/resolve-provider";
 import type { GeneratedInsight } from "../llm/types";
-import { banner, info, warn } from "../output";
+import { banner, info, success, warn } from "../output";
 import { ask, closePrompt } from "../prompt";
 import { displayInsight, saveInsightDraft } from "./insight-shared";
 
 // Same threshold as the extension watcher — see watcher.ts for rationale.
 const DEDUP_JACCARD_THRESHOLD = 0.5;
+
+type InsightMode = "legacy" | "gap" | "both";
+
+function getInsightMode(): InsightMode {
+	const raw = process.env.PULSE_INSIGHT_MODE ?? "legacy";
+	return raw === "gap" || raw === "both" ? raw : "legacy";
+}
 
 function parseTrigger(args: string[]): TriggerType {
 	for (const arg of args) {
@@ -66,9 +81,51 @@ export async function insightCommand(args: string[]): Promise<void> {
 	info(
 		`Context: ${context.transcript ? "transcript" : "no transcript"}, ${context.diff ? "diff" : "no diff"}, ${context.recentCommits ? "commits" : "no commits"}`,
 	);
-	info("Generating insight via LLM...");
 
 	const provider = await getProviderWithSetup(llmConfig);
+	const mode = getInsightMode();
+
+	// Gap-extraction pipeline — one draft per human-intervention window.
+	// Runs in `gap` and `both` modes; in `both` the legacy flow runs after.
+	if (mode === "gap" || mode === "both") {
+		if (!context.transcript) {
+			warn("Gap mode requires a session transcript — skipping gap extraction");
+		} else {
+			info("Generating gap insights from transcript windows...");
+			const sessionInfo = getActiveSessionInfo(process.cwd());
+			const sessionRefs = sessionInfo
+				? [{ session_id: sessionInfo.sessionId, device: hostname(), tool: "cli" }]
+				: undefined;
+			const result = await generateGapInsights(
+				(systemPrompt, userPrompt) => provider.generate(systemPrompt, userPrompt),
+				GAP_INSIGHT_SYSTEM_PROMPT,
+				context.transcript,
+				{
+					onProgress: (idx, total) => info(`  gap ${idx}/${total}…`),
+				},
+			);
+			for (const { response, privacyConcerns } of result.captured) {
+				const payload: InsightCreate = gapResponseToInsightCreate(response, {
+					repo: config.repo,
+					branch: context.branch,
+					triggerType: trigger,
+					sourceFiles: context.sourceFiles,
+					sessionRefs,
+					privacyConcerns,
+				});
+				await apiPost(config.apiUrl, "/insights", payload, config.token);
+			}
+			success(
+				`Gap pipeline: ${result.captured.length} captured · ${result.rejected.length} rejected · ${result.errors.length} errors`,
+			);
+		}
+		if (mode === "gap") {
+			closePrompt();
+			return;
+		}
+	}
+
+	info("Generating insight via LLM...");
 	let insight: GeneratedInsight;
 
 	try {

--- a/extension/package.json
+++ b/extension/package.json
@@ -49,6 +49,12 @@
 					"default": 5000,
 					"minimum": 1000,
 					"description": "How often to check session file size (in ms)"
+				},
+				"pulse.insightMode": {
+					"type": "string",
+					"enum": ["legacy", "gap", "both"],
+					"default": "legacy",
+					"description": "How the watcher generates drafts. 'legacy' = one summary insight per trigger (current behaviour). 'gap' = one insight per moment where the human intervened in the AI's work (new model — see https://pulse.glie.ai/docs/gap-extraction). 'both' = run both pipelines."
 				}
 			}
 		},

--- a/extension/src/llm/direct-provider.ts
+++ b/extension/src/llm/direct-provider.ts
@@ -93,13 +93,30 @@ export async function generateInsightDirect(
 	model: string | undefined,
 	context: InsightContext,
 ): Promise<GeneratedInsight> {
-	const resolvedModel = model || DEFAULT_MODELS[provider];
-	const userPrompt = buildUserPrompt(context);
-
-	const rawText =
-		provider === "anthropic"
-			? await callAnthropic(apiKey, resolvedModel, SYSTEM_PROMPT, userPrompt)
-			: await callOpenAI(apiKey, resolvedModel, SYSTEM_PROMPT, userPrompt);
-
+	const rawText = await callLlmDirect(
+		provider,
+		apiKey,
+		model,
+		SYSTEM_PROMPT,
+		buildUserPrompt(context),
+	);
 	return parseInsightResponse(rawText);
+}
+
+/**
+ * Lower-level: call the direct API with arbitrary system+user prompts.
+ * Used by the gap-extraction pipeline where each window has its own
+ * prompt pair.
+ */
+export async function callLlmDirect(
+	provider: "anthropic" | "openai",
+	apiKey: string,
+	model: string | undefined,
+	systemPrompt: string,
+	userPrompt: string,
+): Promise<string> {
+	const resolvedModel = model || DEFAULT_MODELS[provider];
+	return provider === "anthropic"
+		? callAnthropic(apiKey, resolvedModel, systemPrompt, userPrompt)
+		: callOpenAI(apiKey, resolvedModel, systemPrompt, userPrompt);
 }

--- a/extension/src/llm/generate.ts
+++ b/extension/src/llm/generate.ts
@@ -13,9 +13,9 @@ import { join } from "node:path";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@pulse/cli/llm/prompt";
 import type { GeneratedInsight, InsightContext } from "@pulse/cli/llm/types";
 import * as vscode from "vscode";
-import { generateInsightDirect } from "./direct-provider";
+import { callLlmDirect, generateInsightDirect } from "./direct-provider";
 import { parseInsightResponse } from "./parse";
-import { generateInsightVscodeLm } from "./vscode-lm";
+import { callVscodeLm, generateInsightVscodeLm } from "./vscode-lm";
 
 /**
  * Find Claude Code CLI binary from the installed VS Code extension.
@@ -207,6 +207,63 @@ export class NoLlmError extends Error {
 
 function inferProvider(apiKey: string): "anthropic" | "openai" {
 	return apiKey.startsWith("sk-ant-") ? "anthropic" : "openai";
+}
+
+/**
+ * Call the available LLM with arbitrary system+user prompts and return the
+ * raw text output. Same waterfall as `generateInsight` (vscode.lm → Claude
+ * CLI → Codex CLI → manual API key) but generic — no schema parsing.
+ *
+ * Used by the gap-extraction pipeline, which runs one LLM call per
+ * human-intervention window with a focused prompt each time.
+ */
+export async function callLlm(systemPrompt: string, userPrompt: string): Promise<string> {
+	const config = vscode.workspace.getConfiguration("pulse");
+	const provider = config.get<string>("llmProvider") ?? "auto";
+	const apiKey = config.get<string>("llmApiKey") ?? "";
+	const model = config.get<string>("llmModel") || undefined;
+
+	if (provider === "anthropic" || provider === "openai") {
+		if (!apiKey) {
+			throw new Error(
+				`LLM provider set to "${provider}" but no API key configured. Set pulse.llmApiKey in VS Code settings.`,
+			);
+		}
+		return callLlmDirect(provider, apiKey, model, systemPrompt, userPrompt);
+	}
+
+	try {
+		return await callVscodeLm(systemPrompt, userPrompt);
+	} catch (err) {
+		console.warn(
+			`vscode.lm failed, trying next provider: ${err instanceof Error ? err.message : "unknown"}`,
+		);
+	}
+
+	const claudeBinary = findClaudeCodeBinary();
+	if (claudeBinary) {
+		try {
+			return await runClaudeCli(claudeBinary, systemPrompt, userPrompt, model);
+		} catch (err) {
+			console.warn(`Claude CLI failed: ${err instanceof Error ? err.message : "unknown"}`);
+		}
+	}
+
+	if (isCodexOnPath()) {
+		try {
+			// Codex CLI doesn't accept a separate system prompt — fold it into the user prompt.
+			return await runCodexCli(`${systemPrompt}\n\n---\n\n${userPrompt}`, model);
+		} catch (err) {
+			console.warn(`Codex CLI failed: ${err instanceof Error ? err.message : "unknown"}`);
+		}
+	}
+
+	if (apiKey) {
+		const inferred = inferProvider(apiKey);
+		return callLlmDirect(inferred, apiKey, model, systemPrompt, userPrompt);
+	}
+
+	throw new NoLlmError();
 }
 
 export async function generateInsight(context: InsightContext): Promise<GeneratedInsight> {

--- a/extension/src/llm/vscode-lm.ts
+++ b/extension/src/llm/vscode-lm.ts
@@ -48,11 +48,21 @@ async function selectModel(): Promise<vscode.LanguageModelChat> {
  * Uses whatever LLM the user has available (Copilot, Claude Code, etc.)
  */
 export async function generateInsightVscodeLm(context: InsightContext): Promise<GeneratedInsight> {
+	const fullText = await callVscodeLm(SYSTEM_PROMPT, buildUserPrompt(context));
+	return parseInsightResponse(fullText);
+}
+
+/**
+ * Lower-level: call the vscode.lm API with arbitrary system+user prompts and
+ * return the raw model output. Used by gap-extraction where each window has
+ * its own prompt pair.
+ */
+export async function callVscodeLm(systemPrompt: string, userPrompt: string): Promise<string> {
 	const model = await selectModel();
 
 	const messages = [
-		vscode.LanguageModelChatMessage.User(SYSTEM_PROMPT),
-		vscode.LanguageModelChatMessage.User(buildUserPrompt(context)),
+		vscode.LanguageModelChatMessage.User(systemPrompt),
+		vscode.LanguageModelChatMessage.User(userPrompt),
 	];
 
 	const response = await model.sendRequest(messages, {
@@ -60,12 +70,9 @@ export async function generateInsightVscodeLm(context: InsightContext): Promise<
 			"Pulse uses LLM to generate development knowledge insights from your coding session.",
 	});
 
-	// Collect streaming response
 	const parts: string[] = [];
 	for await (const fragment of response.text) {
 		parts.push(fragment);
 	}
-
-	const fullText = parts.join("");
-	return parseInsightResponse(fullText);
+	return parts.join("");
 }

--- a/extension/src/watcher/watcher.ts
+++ b/extension/src/watcher/watcher.ts
@@ -1,14 +1,27 @@
 import { execSync } from "node:child_process";
 import { getAllActiveSessions, getSessionTitle } from "@pulse/cli/context/session";
-import { findDuplicateBySourceFiles, saveDraft } from "@pulse/shared";
+import {
+	GAP_INSIGHT_SYSTEM_PROMPT,
+	findDuplicateBySourceFiles,
+	gapResponseToInsightCreate,
+	generateGapInsights,
+	saveDraft,
+} from "@pulse/shared";
 import type { InsightCreate } from "@pulse/shared";
 import * as vscode from "vscode";
 import type { PulseApiClient } from "../api/client";
 import type { PulseExtensionConfig } from "../config";
 import { gatherContext } from "../context/gather";
-import { generateInsight } from "../llm/generate";
+import { callLlm, generateInsight } from "../llm/generate";
 import type { DraftsTreeProvider } from "../providers/drafts-tree";
 import type { WatcherTreeProvider } from "../providers/watcher-tree";
+
+type InsightMode = "legacy" | "gap" | "both";
+
+function getInsightMode(): InsightMode {
+	const raw = vscode.workspace.getConfiguration("pulse").get<string>("insightMode") ?? "legacy";
+	return raw === "gap" || raw === "both" ? raw : "legacy";
+}
 
 interface TrackedSession {
 	sessionId: string;
@@ -299,24 +312,60 @@ export class PulseWatcher implements vscode.Disposable {
 			}
 		}
 
-		const generated = await generateInsight(context);
+		const mode = getInsightMode();
 
-		const data: InsightCreate = {
-			kind: generated.kind,
-			title: generated.title,
-			body: generated.body,
-			structured: generated.structured,
-			repo: context.repo,
-			branch: context.branch,
-			source_files: generated.sourceFiles,
-			trigger_type: triggerType,
-			status: "draft",
-		};
+		// Gap-extraction pipeline: one draft per human-intervention window.
+		// The legacy single-insight pipeline runs in `legacy` and `both` modes.
+		if (mode === "gap" || mode === "both") {
+			if (!context.transcript) {
+				this.log("Gap mode: no transcript available — skipping gap extraction");
+			} else {
+				const result = await generateGapInsights(
+					(systemPrompt, userPrompt) => callLlm(systemPrompt, userPrompt),
+					GAP_INSIGHT_SYSTEM_PROMPT,
+					context.transcript,
+				);
+				for (const { response, privacyConcerns } of result.captured) {
+					const data = gapResponseToInsightCreate(response, {
+						repo: context.repo,
+						branch: context.branch,
+						triggerType,
+						sourceFiles: context.sourceFiles,
+						privacyConcerns,
+					});
+					saveDraft(data);
+				}
+				if (result.captured.length > 0) this.draftsTree.refresh();
+				this.log(
+					`Gap drafts saved (${triggerType}): ${result.captured.length} captured · ${result.rejected.length} rejected · ${result.errors.length} errors`,
+				);
+				if (result.captured.length > 0) {
+					vscode.window.showInformationMessage(
+						`Pulse Watcher: ${result.captured.length} gap${result.captured.length === 1 ? "" : "s"} captured`,
+					);
+				}
+			}
+		}
 
-		saveDraft(data);
-		this.draftsTree.refresh();
-		this.log(`Draft saved locally (${triggerType}): "${generated.title}"`);
-		vscode.window.showInformationMessage(`Pulse Watcher: Draft — "${generated.title}"`);
+		if (mode === "legacy" || mode === "both") {
+			const generated = await generateInsight(context);
+			const data: InsightCreate = {
+				kind: generated.kind,
+				title: generated.title,
+				body: generated.body,
+				structured: generated.structured,
+				repo: context.repo,
+				branch: context.branch,
+				source_files: generated.sourceFiles,
+				trigger_type: triggerType,
+				status: "draft",
+			};
+
+			saveDraft(data);
+			this.draftsTree.refresh();
+			this.log(`Draft saved locally (${triggerType}): "${generated.title}"`);
+			vscode.window.showInformationMessage(`Pulse Watcher: Draft — "${generated.title}"`);
+		}
 	}
 
 	private getCurrentCommitHash(cwd: string): string {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -30,13 +30,25 @@ export { GAP_INSIGHT_SYSTEM_PROMPT, INSIGHT_SYSTEM_PROMPT } from "./llm/prompt";
 export {
 	buildGapUserPrompt,
 	extractHumanInterventions,
+	gapResponseToInsightCreate,
+	generateGapInsights,
 	isNoiseMessage,
 	parseGapResponse,
 	parseTranscriptTurns,
+	sanitizeGapResponse,
 } from "./llm/gap";
 export type {
+	GapCaptureOutcome,
+	GapErrorOutcome,
+	GapGenerationOptions,
+	GapGenerationResult,
+	GapInsightCreateContext,
+	GapInsightResolved,
+	GapRejectOutcome,
 	GapResponse,
 	InterventionWindow,
+	LlmCall,
+	SanitizationResult,
 	TranscriptTurn,
 } from "./llm/gap";
 export {

--- a/shared/src/llm/gap.test.ts
+++ b/shared/src/llm/gap.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test } from "bun:test";
 import {
 	buildGapUserPrompt,
 	extractHumanInterventions,
+	gapResponseToInsightCreate,
+	generateGapInsights,
 	isNoiseMessage,
 	parseGapResponse,
 	parseTranscriptTurns,
+	sanitizeGapResponse,
 } from "./gap";
+import type { GapInsightResolved } from "./gap";
 
 describe("parseTranscriptTurns", () => {
 	test("parses alternating USER/ASSISTANT blocks", () => {
@@ -206,5 +210,175 @@ describe("parseGapResponse", () => {
 		expect(r).not.toBeNull();
 		if (!r || r.rejected) throw new Error("expected non-rejected");
 		expect(r.gap_type).toBe("methodology");
+	});
+});
+
+// Test fixture builder for sanitize/generate/mapper tests.
+function makeResolved(overrides: Partial<GapInsightResolved> = {}): GapInsightResolved {
+	return {
+		rejected: false,
+		title: "Sample gap",
+		gap_type: "domain",
+		ai_assumption: "AI was assuming the obvious default.",
+		human_contribution: "Human clarified the actual constraint.",
+		why_invisible_to_ai: "The constraint lives only in domain experts' heads.",
+		for_next_session: "Ask about the constraint up front.",
+		...overrides,
+	};
+}
+
+describe("sanitizeGapResponse", () => {
+	test("strips long quoted spans and records the concern", () => {
+		const input = makeResolved({
+			human_contribution: 'Said "this is a long verbatim quote we want stripped" with frustration.',
+		});
+		const { sanitized, privacyConcerns } = sanitizeGapResponse(input);
+		expect(sanitized.human_contribution).not.toContain("long verbatim quote");
+		expect(sanitized.human_contribution).toContain("[paraphrased]");
+		expect(privacyConcerns.some((c) => c.includes("quoted span"))).toBe(true);
+	});
+
+	test("strips ALL-CAPS runs", () => {
+		const input = makeResolved({ title: "Remove THIS LOUD SHOUTING from the title please" });
+		const { sanitized, privacyConcerns } = sanitizeGapResponse(input);
+		expect(sanitized.title).not.toContain("LOUD SHOUTING");
+		expect(privacyConcerns.some((c) => c.startsWith("title: caps run"))).toBe(true);
+	});
+
+	test("collapses repeated punctuation", () => {
+		const input = makeResolved({ for_next_session: "Just do it!!!! Now???" });
+		const { sanitized } = sanitizeGapResponse(input);
+		expect(sanitized.for_next_session).toBe("Just do it! Now?");
+	});
+
+	test("redacts profanity tokens", () => {
+		const input = makeResolved({ human_contribution: "Indicated that the previous fix was shit." });
+		const { sanitized, privacyConcerns } = sanitizeGapResponse(input);
+		expect(sanitized.human_contribution.toLowerCase()).not.toContain("shit");
+		expect(sanitized.human_contribution).toContain("[redacted]");
+		expect(privacyConcerns.some((c) => c.includes("profanity"))).toBe(true);
+	});
+
+	test("leaves clean input untouched and reports no concerns", () => {
+		const input = makeResolved();
+		const { sanitized, privacyConcerns } = sanitizeGapResponse(input);
+		expect(sanitized).toEqual(input);
+		expect(privacyConcerns).toEqual([]);
+	});
+});
+
+describe("generateGapInsights", () => {
+	test("processes every non-noise window and sanitises outputs", async () => {
+		const transcript = [
+			"[USER] kick-off — please build feature X",
+			"[ASSISTANT] starting work on X with default approach",
+			"[USER] no, use approach Y because the client requires Y",
+			"[ASSISTANT] switching to Y",
+			"[USER] ok",
+			"[ASSISTANT] noted",
+			"[USER] also: domain validation must happen on the server side",
+		].join("\n\n");
+
+		let callIdx = 0;
+		const responses = [
+			JSON.stringify(makeResolved({ title: "Use Y not default approach" })),
+			JSON.stringify(makeResolved({ title: "Domain validation belongs on the server" })),
+		];
+
+		const llm = async () => {
+			const r = responses[callIdx++ % responses.length];
+			return r;
+		};
+
+		const result = await generateGapInsights(llm, "system", transcript);
+		expect(result.captured.length).toBe(2);
+		expect(result.captured[0].response.title).toBe("Use Y not default approach");
+		expect(result.captured[1].response.title).toBe("Domain validation belongs on the server");
+		expect(result.rejected).toEqual([]);
+		expect(result.errors).toEqual([]);
+	});
+
+	test("records rejections from the LLM and parse failures separately", async () => {
+		const transcript = [
+			"[USER] kick-off",
+			"[ASSISTANT] A1",
+			"[USER] actually wait the constraint is different from what I said",
+			"[ASSISTANT] noted",
+			"[USER] one more thing: data residency is important",
+		].join("\n\n");
+
+		const outputs = [
+			JSON.stringify({ rejected: true, reason: "deemed redundant" }),
+			"not json at all",
+		];
+		let i = 0;
+		const llm = async () => outputs[i++ % outputs.length];
+
+		const result = await generateGapInsights(llm, "system", transcript);
+		expect(result.captured).toEqual([]);
+		expect(result.rejected).toHaveLength(1);
+		expect(result.rejected[0].reason).toBe("deemed redundant");
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0].error).toContain("parse");
+	});
+
+	test("respects maxWindows by keeping the most recent N", async () => {
+		const transcript = [
+			"[USER] kick-off",
+			"[ASSISTANT] A1",
+			"[USER] first intervention with enough text to pass the noise filter",
+			"[ASSISTANT] noted A",
+			"[USER] second intervention with enough text to pass the noise filter",
+			"[ASSISTANT] noted B",
+			"[USER] third intervention with enough text to pass the noise filter",
+		].join("\n\n");
+
+		const seen: string[] = [];
+		const llm = async (_sys: string, user: string) => {
+			seen.push(user);
+			return JSON.stringify(makeResolved({ title: "x" }));
+		};
+
+		const result = await generateGapInsights(llm, "system", transcript, { maxWindows: 1 });
+		expect(result.captured).toHaveLength(1);
+		expect(seen[0]).toContain("third intervention");
+	});
+});
+
+describe("gapResponseToInsightCreate", () => {
+	test("maps fields into an InsightCreate of kind=gap", () => {
+		const gap = makeResolved({ title: "T", for_next_session: "Do X next time." });
+		const ic = gapResponseToInsightCreate(gap, {
+			repo: "manager",
+			branch: "main",
+			triggerType: "size",
+			sourceFiles: ["a.ts"],
+		});
+		expect(ic.kind).toBe("gap");
+		expect(ic.title).toBe("T");
+		expect(ic.body).toBe("Do X next time.");
+		expect(ic.structured?.gap_type).toBe("domain");
+		expect(ic.structured?.ai_assumption).toBe("AI was assuming the obvious default.");
+		expect(ic.repo).toBe("manager");
+		expect(ic.branch).toBe("main");
+		expect(ic.trigger_type).toBe("size");
+		expect(ic.source_files).toEqual(["a.ts"]);
+		expect(ic.status).toBe("draft");
+	});
+
+	test("includes privacy_concerns in structured when provided", () => {
+		const gap = makeResolved();
+		const ic = gapResponseToInsightCreate(gap, {
+			repo: "x",
+			triggerType: "manual",
+			privacyConcerns: ["title: caps run redacted"],
+		});
+		expect(ic.structured?.privacy_concerns).toEqual(["title: caps run redacted"]);
+	});
+
+	test("omits privacy_concerns when empty/undefined", () => {
+		const gap = makeResolved();
+		const ic = gapResponseToInsightCreate(gap, { repo: "x", triggerType: "manual" });
+		expect(ic.structured?.privacy_concerns).toBeUndefined();
 	});
 });

--- a/shared/src/llm/gap.ts
+++ b/shared/src/llm/gap.ts
@@ -13,7 +13,7 @@
  * `[ASSISTANT] ...` blocks separated by blank lines.
  */
 
-import type { GapInsightStructured, GapType } from "../types/insight";
+import type { GapInsightStructured, GapType, InsightCreate, TriggerType } from "../types/insight";
 
 // ─── Types ────────────────────────────────────────
 
@@ -230,5 +230,188 @@ export function parseGapResponse(raw: string): GapResponse | null {
 		human_contribution,
 		why_invisible_to_ai,
 		for_next_session,
+	};
+}
+
+// ─── Privacy guard ────────────────────────────────
+
+/**
+ * Patterns that often signal a verbatim leak of the human's voice — the
+ * privacy rule says the insight is the abstraction, not the words. We strip
+ * these post-LLM as a belt-and-braces guard; the prompt also asks the model
+ * to avoid them in the first place.
+ */
+const VERBATIM_QUOTED_RE = /['"`«»][^'"`«»]{12,}['"`«»]/g;
+const CAPS_RUN_RE = /\b[A-Z]{5,}(?:\s+[A-Z]{2,}){0,5}\b/g;
+const REPEATED_PUNCT_RE = /([!?]){2,}/g;
+const LAUGHTER_RE = /\b(k{4,}|h{4,}|a{4,}|j{4,})\b/gi;
+const PROFANITY_RE =
+	/\b(porra|caralho|merda|fds|wtf|fuck(?:ing)?|shit|fodasse|fodase|foda-se|cabrão|cabrao|puta)\b/gi;
+
+export type GapInsightResolved = Extract<GapResponse, { rejected: false }>;
+
+export interface SanitizationResult {
+	sanitized: GapInsightResolved;
+	privacyConcerns: string[];
+}
+
+/**
+ * Strip likely-verbatim spans (quoted strings, ALL-CAPS runs, repeated
+ * punctuation, profanity) from every text field of a non-rejected gap
+ * response. Returns the cleaned response plus a list of human-readable
+ * notes about what was redacted — the caller can store these on the
+ * draft so a human reviewer can spot suspect outputs.
+ */
+export function sanitizeGapResponse(response: GapInsightResolved): SanitizationResult {
+	const concerns: string[] = [];
+
+	const sanitize = (input: string, field: string): string => {
+		let out = input;
+		out = out.replace(VERBATIM_QUOTED_RE, () => {
+			concerns.push(`${field}: quoted span redacted`);
+			return "[paraphrased]";
+		});
+		out = out.replace(CAPS_RUN_RE, (m) => {
+			concerns.push(`${field}: caps run redacted (“${m.slice(0, 24)}”)`);
+			return "[paraphrased]";
+		});
+		out = out.replace(REPEATED_PUNCT_RE, "$1");
+		out = out.replace(LAUGHTER_RE, "");
+		out = out.replace(PROFANITY_RE, () => {
+			concerns.push(`${field}: profanity redacted`);
+			return "[redacted]";
+		});
+		// Collapse any runs of whitespace introduced by redactions
+		out = out.replace(/\s{2,}/g, " ").trim();
+		return out;
+	};
+
+	const sanitized: GapInsightResolved = {
+		...response,
+		title: sanitize(response.title, "title"),
+		ai_assumption: sanitize(response.ai_assumption, "ai_assumption"),
+		human_contribution: sanitize(response.human_contribution, "human_contribution"),
+		why_invisible_to_ai: sanitize(response.why_invisible_to_ai, "why_invisible_to_ai"),
+		for_next_session: sanitize(response.for_next_session, "for_next_session"),
+	};
+
+	return { sanitized, privacyConcerns: concerns };
+}
+
+// ─── Multi-window generation ──────────────────────
+
+/** Provider abstraction: a function that, given system+user prompts, returns raw LLM text. */
+export type LlmCall = (systemPrompt: string, userPrompt: string) => Promise<string>;
+
+export interface GapGenerationOptions {
+	maxWindows?: number; // upper bound on LLM calls per generation; default unlimited
+	onProgress?: (idx: number, total: number) => void;
+}
+
+export interface GapCaptureOutcome {
+	window: InterventionWindow;
+	response: GapInsightResolved;
+	privacyConcerns: string[];
+}
+
+export interface GapRejectOutcome {
+	window: InterventionWindow;
+	reason: string;
+}
+
+export interface GapErrorOutcome {
+	window: InterventionWindow;
+	error: string;
+}
+
+export interface GapGenerationResult {
+	captured: GapCaptureOutcome[];
+	rejected: GapRejectOutcome[];
+	errors: GapErrorOutcome[];
+}
+
+/**
+ * Run gap extraction across every human-intervention window in a transcript.
+ * Sequential by design — provider call rate-limits and retry semantics live
+ * inside the LlmCall implementation, not here.
+ */
+export async function generateGapInsights(
+	llm: LlmCall,
+	systemPrompt: string,
+	transcript: string,
+	opts: GapGenerationOptions = {},
+): Promise<GapGenerationResult> {
+	const turns = parseTranscriptTurns(transcript);
+	let windows = extractHumanInterventions(turns);
+	if (opts.maxWindows !== undefined && windows.length > opts.maxWindows) {
+		// Process the most recent N — older windows have likely been captured
+		// in prior generations and the DB content_hash will dedupe regardless.
+		windows = windows.slice(-opts.maxWindows);
+	}
+
+	const captured: GapCaptureOutcome[] = [];
+	const rejected: GapRejectOutcome[] = [];
+	const errors: GapErrorOutcome[] = [];
+
+	for (let i = 0; i < windows.length; i++) {
+		const w = windows[i];
+		opts.onProgress?.(i + 1, windows.length);
+		try {
+			const raw = await llm(systemPrompt, buildGapUserPrompt(w));
+			const parsed = parseGapResponse(raw);
+			if (!parsed) {
+				errors.push({ window: w, error: "could not parse LLM response" });
+				continue;
+			}
+			if (parsed.rejected) {
+				rejected.push({ window: w, reason: parsed.reason });
+				continue;
+			}
+			const { sanitized, privacyConcerns } = sanitizeGapResponse(parsed);
+			captured.push({ window: w, response: sanitized, privacyConcerns });
+		} catch (err) {
+			errors.push({ window: w, error: err instanceof Error ? err.message : String(err) });
+		}
+	}
+
+	return { captured, rejected, errors };
+}
+
+// ─── Insight create mapper ────────────────────────
+
+export interface GapInsightCreateContext {
+	repo: string;
+	branch?: string;
+	triggerType: TriggerType;
+	sourceFiles?: string[];
+	sessionRefs?: Record<string, unknown>[];
+	privacyConcerns?: string[];
+}
+
+/** Map a sanitized gap response into the shape the API/draft store accepts. */
+export function gapResponseToInsightCreate(
+	gap: GapInsightResolved,
+	ctx: GapInsightCreateContext,
+): InsightCreate {
+	const structured: Record<string, unknown> = {
+		gap_type: gap.gap_type,
+		ai_assumption: gap.ai_assumption,
+		human_contribution: gap.human_contribution,
+		why_invisible_to_ai: gap.why_invisible_to_ai,
+	};
+	if (ctx.privacyConcerns && ctx.privacyConcerns.length > 0) {
+		structured.privacy_concerns = ctx.privacyConcerns;
+	}
+	return {
+		kind: "gap",
+		title: gap.title,
+		body: gap.for_next_session,
+		structured,
+		repo: ctx.repo,
+		branch: ctx.branch,
+		source_files: ctx.sourceFiles,
+		session_refs: ctx.sessionRefs,
+		trigger_type: ctx.triggerType,
+		status: "draft",
 	};
 }


### PR DESCRIPTION
## Why

Phase 1 ([#31](https://github.com/glieai/pulse-ai/pull/31)) shipped the gap-extraction foundation — types, prompt, parsers, helpers — but nothing called it. This PR wires it through both watchers (extension + CLI) behind a feature flag so the team can opt in and validate against real coding sessions.

## What's new

### Shared helpers (`shared/src/llm/gap.ts`)

- **\`sanitizeGapResponse(response)\`** — post-processes every text field of a gap response to strip likely verbatim leaks:
  - Quoted spans of >12 chars → \`[paraphrased]\`
  - ALL-CAPS runs of 5+ chars → \`[paraphrased]\`
  - Repeated punctuation (\`!!!\` → \`!\`)
  - Profanity tokens (PT + EN) → \`[redacted]\`
  - Returns the cleaned response plus a list of redaction notes saved in \`structured.privacy_concerns\` for human review.
- **\`generateGapInsights(llm, systemPrompt, transcript, opts)\`** — top-level orchestrator: parses transcript → extracts intervention windows → calls the provided LLM once per window → parses + sanitises responses → returns \`{ captured, rejected, errors }\`.
- **\`gapResponseToInsightCreate(gap, ctx)\`** — maps a sanitised gap into the existing \`InsightCreate\` shape (kind=\"gap\", body=\`for_next_session\`, structured=other gap fields).

### Generic LLM call surface

- **Extension:** new \`callLlm(systemPrompt, userPrompt)\` in \`extension/src/llm/generate.ts\` runs the existing waterfall (vscode.lm → Claude CLI → Codex CLI → manual API key) but returns raw text. \`vscode-lm.ts\` and \`direct-provider.ts\` got a thin generic primitive each (\`callVscodeLm\`, \`callLlmDirect\`); their \`generateInsight*\` wrappers now delegate to those primitives.
- **CLI:** uses the existing \`provider.generate(systemPrompt, userPrompt)\` method on \`LLMProvider\` — no refactor needed.

### Watcher wiring

- **Extension** (\`extension/src/watcher/watcher.ts\`): reads \`pulse.insightMode\` VS Code setting and branches on \`gap | both | legacy\`. In gap/both mode, runs \`generateGapInsights\` on the session transcript and saves each captured gap via \`saveDraft\`.
- **CLI** (\`cli/src/commands/insight.ts\`): reads \`PULSE_INSIGHT_MODE\` env var (same three values). In gap/both mode, runs gap pipeline and POSTs each gap as a draft to the API.

### Configuration

\`extension/package.json\` adds the \`pulse.insightMode\` setting (default \`legacy\`).

## Default behaviour: unchanged

\`legacy\` mode is the default for both extension and CLI — nothing changes in production until the user opts in. \`both\` mode runs both pipelines for side-by-side comparison. \`gap\` mode runs only the new pipeline.

## Tests

11 new unit tests added (30 total in \`shared/src/llm/gap.test.ts\`):
- sanitize: quoted spans, caps, profanity, repeated punctuation, clean input
- generateGapInsights: success, mixed rejection+error, maxWindows slicing
- gapResponseToInsightCreate: field mapping, privacy_concerns inclusion/omission

\`\`\`
$ bun test shared/src cli/src
72 pass · 0 fail · 138 expect() calls
\`\`\`

\`bun run lint\` clean. \`bun run typecheck\` clean. (api/src/index.test.ts still fails on missing DATABASE_URL — pre-existing in CI setup.)

## Phase 3 (separate PRs to come)

- Mark/move the existing 1.3k legacy insights for filtering
- Per-session turn-index tracking so we don't re-process old windows
- UI updates for gap viewer + a redesigned weekly digest
- MCP tool descriptions updated to reflect the gap-first model

## Test plan
- [x] \`bun run lint\` clean
- [x] \`bun run typecheck\` clean
- [x] \`bun test shared/src cli/src\` 72/72 pass
- [ ] Manual: set \`PULSE_INSIGHT_MODE=gap\` and run \`pulse insight\` on a recent coding session → drafts visible in web UI
- [ ] Manual: set \`pulse.insightMode\` = \`gap\` in VS Code and let watcher fire on size threshold → drafts in tree