### PR TITLE
chore(extension): bump 0.1.25 → 0.1.26 to force marketplace republish

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Pulse AI",
 	"publisher": "glie",
 	"description": "Operational memory for vibe coding teams — capture decisions, dead-ends and patterns from AI coding sessions automatically.",
-	"version": "0.1.25",
+	"version": "0.1.26",
 	"license": "SEE LICENSE IN LICENSE",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Manual version bump. The new INSIGHT_SYSTEM_PROMPT (PR #34) needs to reach users; CD missed the auto-publish path because its detector only matched file-level diffs not submodule pointer diffs.