### PR TITLE
fix(auth-flow): claude-code.focus → claude-vscode.focus

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Pulse AI",
 	"publisher": "glie",
 	"description": "Operational memory for vibe coding teams — capture decisions, dead-ends and patterns from AI coding sessions automatically.",
-	"version": "0.1.26",
+	"version": "0.1.28",
 	"license": "SEE LICENSE IN LICENSE",
 	"repository": {
 		"type": "git",

--- a/extension/src/llm/auth-flow.ts
+++ b/extension/src/llm/auth-flow.ts
@@ -88,7 +88,22 @@ export async function promptLlmSetup(): Promise<boolean> {
 	switch (choice.action) {
 		case "signin-claude": {
 			if (claudeExtension) {
-				await vscode.commands.executeCommand("claude-code.focus");
+				// Try the current command name (v2.1+); fall back to the legacy
+				// one and finally to a generic info message if neither exists.
+				const candidates = ["claude-vscode.focus", "claude-code.focus"];
+				let focused = false;
+				for (const cmd of candidates) {
+					try {
+						await vscode.commands.executeCommand(cmd);
+						focused = true;
+						break;
+					} catch {}
+				}
+				if (!focused) {
+					vscode.window.showInformationMessage(
+						"Open the Claude Code panel and sign in, then retry Pulse.",
+					);
+				}
 			} else {
 				vscode.window.showInformationMessage(
 					"Run 'claude' in your terminal — it will prompt you to sign in. Then retry.",


### PR DESCRIPTION
Claude Code v2 renamed the command. Auth flow now tries both with fallback. Bumps to 0.1.28.