### PR TITLE
feat(insights): drop 'no significant' marker + tighten Rule #7

### DIFF
--- a/cli/src/commands/insight.ts
+++ b/cli/src/commands/insight.ts
@@ -1,5 +1,9 @@
 import { hostname } from "node:os";
-import { type TriggerType, findDuplicateBySourceFiles } from "@pulse/shared";
+import {
+	type TriggerType,
+	findDuplicateBySourceFiles,
+	isNoSignificantContribution,
+} from "@pulse/shared";
 import { loadConfig } from "../config";
 import { gatherContext } from "../context/gather";
 import { getActiveSessionInfo } from "../context/session";
@@ -75,6 +79,13 @@ export async function insightCommand(args: string[]): Promise<void> {
 		insight = await provider.generateInsight(context);
 	} catch (err) {
 		throw new Error(`LLM generation failed: ${err instanceof Error ? err.message : "unknown"}`);
+	}
+
+	// Drop the no-contribution marker — see Rule #7 in INSIGHT_SYSTEM_PROMPT.
+	if (isNoSignificantContribution(insight.title)) {
+		warn("No significant human contribution found in this session — nothing to save.");
+		closePrompt();
+		return;
 	}
 
 	displayInsight(insight);

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Pulse AI",
 	"publisher": "glie",
 	"description": "Operational memory for vibe coding teams — capture decisions, dead-ends and patterns from AI coding sessions automatically.",
-	"version": "0.1.28",
+	"version": "0.1.30",
 	"license": "SEE LICENSE IN LICENSE",
 	"repository": {
 		"type": "git",

--- a/extension/src/watcher/watcher.ts
+++ b/extension/src/watcher/watcher.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { getAllActiveSessions, getSessionTitle } from "@pulse/cli/context/session";
-import { findDuplicateBySourceFiles, saveDraft } from "@pulse/shared";
+import { findDuplicateBySourceFiles, isNoSignificantContribution, saveDraft } from "@pulse/shared";
 import type { InsightCreate } from "@pulse/shared";
 import * as vscode from "vscode";
 import type { PulseApiClient } from "../api/client";
@@ -300,6 +300,15 @@ export class PulseWatcher implements vscode.Disposable {
 		}
 
 		const generated = await generateInsight(context);
+
+		// Skip the special "no significant human contribution" marker — the
+		// LLM emits it when it can't find a real intervention in the
+		// transcript. Saving it would pollute the feed (see Rule #7 in
+		// INSIGHT_SYSTEM_PROMPT).
+		if (isNoSignificantContribution(generated.title)) {
+			this.log(`Skipped (${triggerType}): no significant human contribution detected`);
+			return;
+		}
 
 		const data: InsightCreate = {
 			kind: generated.kind,

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -24,7 +24,11 @@ export type {
 	User,
 	UserRole,
 } from "./types/org";
-export { INSIGHT_SYSTEM_PROMPT } from "./llm/prompt";
+export {
+	INSIGHT_SYSTEM_PROMPT,
+	NO_SIGNIFICANT_CONTRIBUTION_TITLE,
+	isNoSignificantContribution,
+} from "./llm/prompt";
 export {
 	ASK_SYSTEM_PROMPT,
 	buildAskUserPrompt,

--- a/shared/src/llm/prompt.ts
+++ b/shared/src/llm/prompt.ts
@@ -1,4 +1,21 @@
 /**
+ * Special title emitted by the LLM when it cannot find any substantive human
+ * intervention in the session transcript. The watcher/CLI filter checks for
+ * this exact string and silently drops the insight rather than saving it —
+ * see Rule #7 in INSIGHT_SYSTEM_PROMPT. Case-insensitive prefix match in
+ * isNoSignificantContribution() so minor LLM rewording still gets filtered.
+ */
+export const NO_SIGNIFICANT_CONTRIBUTION_TITLE = "no significant human contribution";
+
+/**
+ * True if the LLM marked this insight as having no real human contribution.
+ * Such insights MUST be dropped before saving — see Rule #7.
+ */
+export function isNoSignificantContribution(title: string): boolean {
+	return title.trim().toLowerCase().startsWith(NO_SIGNIFICANT_CONTRIBUTION_TITLE);
+}
+
+/**
  * Shared system prompt for insight generation.
  *
  * This is the "DNA" of what makes a good Pulse insight.
@@ -71,7 +88,7 @@ Pick the one that fits the human contribution best:
 4. **Body length:** 400–1500 chars. Shorter than 300 is too thin; longer than 1500 is bloat.
 5. **No project/repo prefix in title** — that's separate metadata.
 6. **If existing insights are provided, do NOT repeat them.** Find a different gap.
-7. **If the conversation has no real human intervention** (just AI narrating its own work), output \`{ "kind": "progress", "title": "no significant human contribution", "body": "..." }\` and the dedup layer will drop it. Better to emit a low-signal insight that gets filtered than to fabricate substance.
+7. **Before claiming there's no human intervention, prove it.** Re-scan every human message in the transcript. The default assumption is that any human message over 30 characters that contains "no", "but", "actually", "wait", "espera", "mas", or names a constraint/principle/person IS an intervention. ONLY emit \`{ "kind": "progress", "title": "no significant human contribution", "body": "..." }\` if you can enumerate (in the body) the human messages you examined and articulate why EACH ONE is a pure confirmation, unblock, scheduling, or typo correction. If you find ONE substantive correction, pick that as the insight — do not collapse a session of corrections into a "no significant" marker. The downstream filter drops this special marker; if you emit it wrongly, real intervention is lost forever.
 
 ## Output format
 


### PR DESCRIPTION
Two-part fix for the LLM emitting marker when session DID have corrections, then saving it to DB anyway. Tighter prompt + isNoSignificantContribution() filter at save layer. Bumps 0.1.30.